### PR TITLE
Release 0.1.11. Added "Elements"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aoer-plotty-rs"
 description = "A variety of utilities for creating pen-plotter based artwork."
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/armyofevilrobots/aoer-plotty-rs"
@@ -25,3 +25,4 @@ wkt = "0.10"
 rand = "0.8.5"
 splines = "4.1"
 cubic_spline = "1.0"
+#itertools = "0.10"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,31 @@ my days off. May spontaneously explode, might take your plotter with it.*
 [`vsk`]: https://vsketch.readthedocs.io/en/latest/index.html
 
 ## Changelog
+* 0.1.11. Added the first "element" (reusable sketch component) in the form
+         of the [`elements::CarlsonSmithTruchet`], which provides tileable
+         and scalable truchets which make for some very interesting patterns.
+         Thing of them as the "goto 10" tiles on steroids.
+         Also added a to_geos trait which makes it easy to convert
+         back and forth from geo_types without fancy and unpredictable
+         From/Into magic.
+         Also added a [`geo_types::shapes`] module which provides some
+         additional primitives (arc, polygons, circles).
+         Added the [`geo_types::boolean::BooleanOp`] trait to allow for
+         boolean operations directly against geo_types.
+* 0.1.10. Getting close to having to do a 0.2 release. Added the 'flatten'
+         method to [`context::Context`] so that you can merge all your
+         pen strokes that live on the same layer. Good for merging
+         overlapping polygons. Layer is defined as "exact same color, pen,
+         and fill configuration"
+* 0.1.9. Add masking to context: You can now mask the drawable area with
+         any [`geo_types::Geometry`] variant and only areas under the mask
+         will actually render. Also changed some performance and accuracy
+         related optimizations so that clipped items look clean.
+         Also added the final Generative Artistry examples. I'll miss
+         implementing those :(
+* 0.1.8. Add a bunch of new features to Context, including regular polygons
+         and tesselated polys (stars of various point counts). Circles are
+         now somewhat simpler as well.
 * 0.1.7. Another big change. Added the Context drawing library, which is HUGE,
   and contains way too much functionality to discuss here.
 * 0.1.6. Various changes:

--- a/examples/carlson_smith_nannou.rs
+++ b/examples/carlson_smith_nannou.rs
@@ -1,0 +1,110 @@
+use geo_types::MultiLineString;
+use aoer_plotty_rs::geo_types::nannou::NannouDrawer;
+use nannou::prelude::*;
+use nannou::color;
+use nannou::lyon::lyon_tessellation::LineJoin;
+use nannou::lyon::tessellation::LineCap;
+use aoer_plotty_rs::context::Context as AOERCTX;
+use aoer_plotty_rs::elements::CarlsonSmithTruchet;
+use aoer_plotty_rs::prelude::LineHatch;
+
+/// The Model contains just the loop count (number of frames) and the tlines (turtle lines)
+/// MultiLineString that contains the gosper curve.
+struct Model {
+    loops: u32,
+    tlines: MultiLineString<f64>,
+}
+
+/// Creates a new turtle, then a new gosper LSystem. Walks the Gosper path after expanding
+/// the LSystem, and then spits out a multiline string which we use to populate the Model.
+/// Also centers the resulting MultiLineString on the 0,0 point in the middle of the screen.
+fn model(_app: &App) -> Model {
+    let mut ctx = AOERCTX::new();
+    let mut count = 0;
+
+    ctx.pen(1.0)
+        .pattern(LineHatch::gen());
+
+    for (name, geo) in CarlsonSmithTruchet::full_set(false) {
+        println!("Plotting {}", name);
+        let yofs: f64 = -128.0f64 + 64.0f64 * <f64 as From<i32>>::from((count / 6) as i32);
+        let xofs: f64 = -128.0f64 + 64.0f64 * <f64 as From<i32>>::from((count % 6) as i32);
+        let tx =
+            AOERCTX::translate_matrix(xofs, yofs) *
+                AOERCTX::scale_matrix(64.0, 64.0);
+        count += 1;
+        ctx.transform(Some(&tx))
+            .geometry(&geo);
+    }
+    count = 0;
+    for (name, geo) in CarlsonSmithTruchet::full_set(true) {
+        println!("Plotting inverse scale/2 {}", name);
+        let yofs: f64 = -128.0f64 - 16.0f64 + 32.0f64 * <f64 as From<i32>>::from((count / 6) as i32);
+        let xofs: f64 = -128.0f64 - 16.0f64 + (64.0f64 * 6.0f64) + 32.0f64 * <f64 as From<i32>>::from((count % 6) as i32);
+        let tx =
+            AOERCTX::translate_matrix(xofs, yofs) *
+                AOERCTX::scale_matrix(32.0, 32.0);
+        count += 1;
+        ctx.transform(Some(&tx))
+            .geometry(&geo);
+    }
+
+
+    println!("Flattening...");
+    let layers = ctx.flatten().to_layers();
+    println!("Done flattening");
+
+    let mut outlines = vec![];
+    let mut fills = vec![];
+    let mut all_lines: MultiLineString<f64> = MultiLineString::new(vec![]);
+
+    for layer in &layers {
+        let (o, f) = layer.to_lines();
+        outlines.extend(o);
+        fills.extend(f);
+    }
+
+    all_lines.0.extend(outlines);
+    all_lines.0.extend(fills);
+
+    // We're done. Save it in the model.
+    Model {
+        loops: 0,
+        tlines: all_lines,
+    }
+}
+
+fn update(_app: &App, _model: &mut Model, _update: Update) {
+    // Update the var used to spin the gosper
+    _model.loops += 1;
+}
+
+fn view(_app: &App, _model: &Model, frame: Frame) {
+    // Broilerplate Nannou
+    // And slowly spin it
+    let draw = _app.draw().rotate((_model.loops as f32) * PI/180.0);
+    frame.clear(PURPLE);
+
+    // Draw the turtle lines into the draw context
+    _model.tlines.iter().for_each(|tline| {
+        draw.polyline()
+            .stroke_weight(1.0)
+            .caps(LineCap::Round)
+            .join(LineJoin::Round)
+            .polyline_from_linestring(tline)
+            .color(color::NAVY);
+    });
+
+
+    // Done. Put it on the screen
+    draw.to_frame(_app, &frame).unwrap();
+}
+
+fn main() {
+    // Basic Nannou setup.
+    nannou::app(model)
+        .update(update)
+        .simple_window(view)
+        .run();
+}
+

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -16,9 +16,9 @@ use geo::map_coords::MapCoords;
 use geos::{Geom, GeometryTypes};
 use nalgebra::{Affine2, Matrix3, Point2 as NPoint2};
 use nannou::prelude::PI_F64;
-use num_traits::FromPrimitive;
 use crate::geo_types::clip::{LineClip, try_to_geos_geometry};
 use crate::errors::ContextError;
+use crate::geo_types::shapes;
 
 /// Operations are private items used to store the operation stack
 /// consisting of a combination of Geometry and Context state.
@@ -128,6 +128,25 @@ impl Operation {
         (outlines, fills)
     }
 }
+
+
+/// OPLayer is an operation layer, rendered into lines for drawing.
+pub struct OPLayer {
+    stroke_lines: MultiLineString<f64>,
+    fill_lines: MultiLineString<f64>,
+    stroke: String,
+    fill: String,
+    stroke_width: f64,
+    stroke_linejoin: String,
+    stroke_linecap: String,
+}
+
+impl OPLayer {
+    pub fn to_lines(&self) -> (MultiLineString<f64>, MultiLineString<f64>) {
+        (self.stroke_lines.clone(), self.fill_lines.clone())
+    }
+}
+
 
 /// # Context
 ///
@@ -521,27 +540,29 @@ impl Context {
     /// Draw an arc around x0,y0 with the given radius, from deg0 to deg1. Arcs will always be
     /// coords oriented clockwise from "north" on an SVG. ie: 45 to 135 will be NE to SE.
     pub fn arc_center(&mut self, x0: f64, y0: f64, radius: f64, deg0: f64, deg1: f64) -> &mut Self {
-        let radius = radius.abs();
-        // Clamp the angle.
-        let deg0 = PI_F64 * ((deg0 % 360.0) / 180.0);
-        let deg1 = PI_F64 * ((deg1 % 360.0) / 180.0);
-        let (deg0, deg1) = if deg0 > deg1 {
-            (deg1, deg0)
-        } else {
-            (deg0, deg1)
-        };
-        let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
-        let segments = (deg1 - deg0) * f64::from(sides as i32).floor();
-        let seg_size = (deg1 - deg0) / segments;
-        let mut ls = LineString::<f64>::new(vec![]);
-        let mut angle = deg0;
-        for _segment in 0..(segments as i32) {
-            ls.0.push(coord! {x: x0+radius*angle.sin(), y: y0+radius*angle.cos()});
-            angle += seg_size;
-        }
-        if deg1 - angle > 0.0 {
-            ls.0.push(coord! {x: x0+radius*deg1.sin(), y: y0+radius*deg1.cos()});
-        }
+        // let radius = radius.abs();
+        // // Clamp the angle.
+        // let deg0 = PI_F64 * ((deg0 % 360.0) / 180.0);
+        // let deg1 = PI_F64 * ((deg1 % 360.0) / 180.0);
+        // let (deg0, deg1) = if deg0 > deg1 {
+        //     (deg1, deg0)
+        // } else {
+        //     (deg0, deg1)
+        // };
+        // let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
+        // let segments = (deg1 - deg0) * f64::from(sides as i32).floor();
+        // let seg_size = (deg1 - deg0) / segments;
+        // let mut ls = LineString::<f64>::new(vec![]);
+        // let mut angle = deg0;
+        // for _segment in 0..(segments as i32) {
+        //     ls.0.push(coord! {x: x0+radius*angle.sin(), y: y0+radius*angle.cos()});
+        //     angle += seg_size;
+        // }
+        // if deg1 - angle > 0.0 {
+        //     ls.0.push(coord! {x: x0+radius*deg1.sin(), y: y0+radius*deg1.cos()});
+        // }
+        let ls = crate::geo_types::shapes::arc_center(x0, y0, radius, deg0, deg1);
+        let ls = ls.map_coords(|(x,y)| (x.clone(), -y.clone()));
         self.add_operation(Geometry::LineString(ls));
 
         self
@@ -590,24 +611,27 @@ impl Context {
     /// Draws a circle. Actually just buffers a point, and returns a polygon
     /// which it draws on the context.
     pub fn circle(&mut self, x0: f64, y0: f64, radius: f64) -> &mut Self {
-        let radius = radius.abs();
-        let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
-        self.regular_poly(sides, x0, y0, radius, 0.0)
+        // let radius = radius.abs();
+        // let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
+        // self.regular_poly(sides, x0, y0, radius, 0.0)
+        self.add_operation(shapes::circle(x0, y0, radius));
+        self
     }
 
     /// Circumscribed regular polygon. The vertices of the polygon will be situated on a
     /// circle defined by the given radius. Polygon will be centered at x,y.
     pub fn regular_poly(&mut self, sides: usize, x: f64, y: f64, radius: f64, rotation: f64) -> &mut Self {
         // all the way around to the start again, and hit the first point twice to close it.
-        if sides < 3 { return self; };
-
-        let geo = Geometry::Polygon(Polygon::new(LineString::new((0..(sides + 2))
-            .map(|i| {
-                let angle = rotation - PI_F64 / 2.0 +
-                    (f64::from(i as i32) / f64::from(sides as i32)) * (2.0 * PI_F64);
-                coord! {x: x+angle.cos() * radius, y: y+angle.sin() * radius}
-            }).collect()
-        ), vec![]));
+        // if sides < 3 { return self; };
+        //
+        // let geo = Geometry::Polygon(Polygon::new(LineString::new((0..(sides + 2))
+        //     .map(|i| {
+        //         let angle = rotation - PI_F64 / 2.0 +
+        //             (f64::from(i as i32) / f64::from(sides as i32)) * (2.0 * PI_F64);
+        //         coord! {x: x+angle.cos() * radius, y: y+angle.sin() * radius}
+        //     }).collect()
+        // ), vec![]));
+        let geo = shapes::regular_poly(sides, x, y, radius, rotation);
         self.add_operation(geo);
         self
     }
@@ -710,14 +734,17 @@ impl Context {
             &tmp_gt_op)
             .unwrap_or(geos::Geometry::create_empty_collection(GeometryTypes::GeometryCollection)
                 .expect("Failed to generate default geos::geometry"));
+        // let mut interim_geo = geos::Geometry::create_empty_collection(GeometryTypes::GeometryCollection)?;
         for operation in self.operations.iter() {
             if operation.consistent(&last_operation) {
                 // Union current_geometry with the operation
                 let cgeo = try_to_geos_geometry(&operation.content)
                     .unwrap_or(geos::Geometry::create_empty_collection(GeometryTypes::GeometryCollection)
                         .expect("Failed to generate default geos::geometry"));
-                current_geometry = cgeo.union(&current_geometry)
-                    .unwrap_or(Geom::clone(&current_geometry));
+                // current_geometry = cgeo.union(&current_geometry)
+                //     .unwrap_or(Geom::clone(&current_geometry));
+                current_geometry = geos::Geometry::create_geometry_collection(vec![current_geometry, cgeo])
+                    .expect("Cannot append geometry into collection.");
             } else {
                 // Duplicate the state into the context, and create a new current_geometry bundle
                 new_ctx.stroke_color = operation.stroke_color.clone();
@@ -729,6 +756,10 @@ impl Context {
                 new_ctx.clip_previous = operation.clip_previous.clone();
                 new_ctx.hatch_pattern = operation.hatch_pattern.clone();
                 new_ctx.hatch_angle = operation.hatch_angle;
+
+                current_geometry = current_geometry
+                    .unary_union()
+                    .unwrap_or(current_geometry);
 
                 new_ctx.geometry(&geo_types::Geometry::try_from(current_geometry)
                     .unwrap_or(
@@ -742,6 +773,9 @@ impl Context {
             }
         }
         // get the last one.
+        current_geometry = current_geometry
+            .unary_union()
+            .unwrap_or(current_geometry);
         new_ctx.geometry(&geo_types::Geometry::try_from(current_geometry)
             .unwrap_or(
                 Geometry::GeometryCollection(
@@ -758,22 +792,8 @@ impl Context {
         Ok(Geometry::GeometryCollection(GeometryCollection::<f64>::new_from(all)))
     }
 
-
-    /// Take this giant complex thing and generate and SVG Document, or an error. Whatever.
-    pub fn to_svg(&self, arrangement: &Arrangement<f64>) -> Result<Document, ContextError> {
-        struct OPLayer {
-            stroke_lines: MultiLineString<f64>,
-            fill_lines: MultiLineString<f64>,
-            stroke: String,
-            fill: String,
-            stroke_width: f64,
-            stroke_linejoin: String,
-            stroke_linecap: String,
-        }
-
-        let mut svg = arrangement
-            .create_svg_document()
-            .or(Err(ContextError::SvgGenerationError("Failed to create raw svg doc".into()).into()))?;
+    /// Generate layers of perimeters and fills
+    pub fn to_layers(&self) -> Vec<OPLayer> {
         let mut oplayers: Vec<OPLayer> = vec![];
         for op in &self.operations {
             // let (stroke, fill) = op.render_to_lines();
@@ -808,6 +828,16 @@ impl Context {
                 }
             }
         }
+        oplayers
+    }
+
+    /// Take this giant complex thing and generate and SVG Document, or an error. Whatever.
+    pub fn to_svg(&self, arrangement: &Arrangement<f64>) -> Result<Document, ContextError> {
+        let oplayers = self.to_layers();
+
+        let mut svg = arrangement
+            .create_svg_document()
+            .or(Err(ContextError::SvgGenerationError("Failed to create raw svg doc".into()).into()))?;
 
         let mut id = 0;
         for oplayer in oplayers {
@@ -884,7 +914,7 @@ mod test {
             .arc_center(0.0, 0.0, 10.0, 180.0, 45.0);
         let arrangement = Arrangement::unit(&Rect::new(coord! {x: 0.0, y: 0.0}, coord! {x:100.0, y:100.0}));
         let svg2 = context.to_svg(&arrangement).unwrap();
-        println!("SVG ARC IS: {}", svg2.to_string());
+        // println!("SVG ARC IS: {}", svg2.to_string());
         // Make sure that order of angles is irrelevant
         assert_eq!(svg2.to_string(), svg1.to_string());
     }
@@ -945,8 +975,8 @@ mod test {
         assert_eq!(svg.to_string(),
                    concat!(
                    "<svg height=\"100mm\" viewBox=\"0 0 100 100\" width=\"100mm\" xmlns=\"http://www.w3.org/2000/svg\">\n",
-                   "<path d=\"M20,40 L40,40 L40,20 L30,20 L30,10 L10,10 L10,30 L20,30 L20,40\" fill=\"none\" id=\"outline-0\" stroke=\"red\" stroke-linecap=\"round\" ",
-                   "stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n</svg>"
+                   "<path d=\"M30,10 L10,10 L10,30 L20,30 L20,40 L40,40 L40,20 L30,20 L30,10\" fill=\"none\" id=\"outline-0\" ",
+                   "stroke=\"red\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n</svg>"
                    ));
     }
 
@@ -968,16 +998,18 @@ mod test {
         context = context.flatten();
         let arrangement = Arrangement::unit(&Rect::new(coord! {x: 0.0, y: 0.0}, coord! {x:100.0, y:100.0}));
         let svg = context.to_svg(&arrangement).unwrap();
-        println!("svg: {}", svg.to_string());
+        // println!("svg: {}", svg.to_string());
         assert_eq!(svg.to_string(),
-                   concat!("<svg height=\"100mm\" viewBox=\"0 0 100 100\" width=\"100mm\" xmlns=\"http://www.w3.org/2000/svg\">\n",
+                   concat!(
+                   "<svg height=\"100mm\" viewBox=\"0 0 100 100\" width=\"100mm\" xmlns=\"http://www.w3.org/2000/svg\">\n",
                    "<path d=\"\" fill=\"none\" id=\"outline-0\" stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n",
                    "<path d=\"\" fill=\"none\" id=\"fill-0\" stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n",
-                   "<path d=\"M32,48 L48,48 L48,32 L40,32 L40,20 L30,20 L30,10 L10,10 L10,30 L20,30 L20,40 L32,40 L32,48\" fill=\"none\" id=\"outline-1\" ",
-                   "stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n<path d=\"\" fill=\"none\" id=\"fill-1\" ",
-                   "stroke=\"blue\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n",
-                   "<path d=\"M22,22 L38,22 L38,38 L22,38 L22,22\" fill=\"none\" id=\"outline-2\" stroke=\"black\" ",
-                   "stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n</svg>"));
+                   "<path d=\"M30,10 L10,10 L10,30 L20,30 L20,40 L32,40 L32,48 L48,48 L48,32 L40,32 L40,20 L30,20 L30,10\" fill=\"none\" id=\"outline-1\" ",
+                   "stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n",
+                   "<path d=\"\" fill=\"none\" id=\"fill-1\" stroke=\"blue\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n",
+                   "<path d=\"M22,22 L38,22 L38,38 L22,38 L22,22\" fill=\"none\" id=\"outline-2\" stroke=\"black\" stroke-linecap=\"round\" ",
+                   "stroke-linejoin=\"round\" stroke-width=\"0.5\"/>\n</svg>"
+                   ));
     }
 
     #[test]
@@ -991,15 +1023,15 @@ mod test {
             .rect(10.0, 10.0, 90.0, 90.0);
 
         let foo = context.to_geo().unwrap();
-        println!("OFOO IS {:?}", &foo);
+        // println!("OFOO IS {:?}", &foo);
         let mut context = Context::new();
         context.stroke("green");
         context.pen(0.8);
         context.fill("purple");
         context.geometry(&foo);
         let arrangement = Arrangement::unit(&Rect::new(coord! {x: 0.0, y: 0.0}, coord! {x:100.0, y:100.0}));
-        let svg = context.to_svg(&arrangement).unwrap();
-        println!("svg : {}", svg.to_string());
+        /*let svg =*/ context.to_svg(&arrangement).unwrap();
+        // println!("svg : {}", svg.to_string());
     }
 
     #[test]

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,28 +1,298 @@
-pub mod carlson_smith_truchet {
+use std::collections::HashMap;
+use std::error::Error;
+use std::rc::Rc;
+use geo::rotate::RotatePoint;
+use geo_types::{coord, Geometry, GeometryCollection, LineString, Point, point, Rect};
+use crate::geo_types::shapes::arc_center;
+use crate::geo_types::buffer::Buffer;
+use crate::geo_types::boolean::BooleanOp;
 
-    pub enum CarlsonSmithTruchet{
-        TLBR(bool),
-        DIV(bool),
-        DOTS(bool),
-        PINWHEEL(bool),
-        PLUS(bool),
-        UNHAPPY(bool),
-        HUGS(bool)
+pub enum CarlsonSmithTruchet {
+    TLBR(bool),
+    DIV(bool),
+    DOTS(bool),
+    PINWHEEL(bool),
+    PLUS(bool),
+    UNHAPPY(bool),
+    HUGS(bool),
+}
+
+impl CarlsonSmithTruchet {
+
+    pub fn full_set(invert: bool) -> HashMap<String, Rc<Geometry<f64>>>{
+        let mut truchets = HashMap::new();
+        for i in (0..360).step_by(90){
+            truchets.insert(format!("TLBR{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::TLBR(invert)
+                                    .draw()
+                                    .unwrap()
+                                    .rotate_around_point(
+                                        f64::from(i),
+                                        point!{x: 0.0, y: 0.0})));
+            truchets.insert(format!("DIV{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::DIV(invert)
+                                    .draw()
+                                    .unwrap()
+                                    .rotate_around_point(
+                                        f64::from(i),
+                                        point!{x: 0.0, y: 0.0})));
+            truchets.insert(format!("UNHAPPY{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::UNHAPPY(invert)
+                                    .draw()
+                                    .unwrap()
+                                    .rotate_around_point(
+                                        f64::from(i),
+                                        point!{x: 0.0, y: 0.0})));
+            truchets.insert(format!("HUGS{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::HUGS(invert)
+                                    .draw()
+                                    .unwrap()
+                                    .rotate_around_point(
+                                        f64::from(i),
+                                        point!{x: 0.0, y: 0.0})));
+            // All teh dots are identical
+            truchets.insert(format!("DOTS{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::DOTS(invert)
+                                    .draw()
+                                    .unwrap()));
+            truchets.insert(format!("PINWHEEL{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::PINWHEEL(invert)
+                                    .draw()
+                                    .unwrap()));
+            truchets.insert(format!("PLUS{}", i),
+                            Rc::new(
+                                CarlsonSmithTruchet::PLUS(invert)
+                                    .draw()
+                                    .unwrap()));
+
+
+
+        }
+        truchets
     }
 
+    /// Returns the Geometry for the given truchet, centered on 0.0, with a scale of 1.0
+    pub fn draw(&self) -> Result<Geometry<f64>, Box<dyn Error>> {
+        match self {
+            CarlsonSmithTruchet::TLBR(false) => {
+                let mut ac1 = Geometry::LineString(
+                    arc_center(0.5, 0.5, 0.5, 180.0, 270.0))
+                    .buffer(1.0f64 / 6.0f64)?; // Buffer is 1/2 of 1/3
+                let ac2 = Geometry::LineString(
+                    arc_center(-0.5, -0.5, 0.5, 90.0, 0.0))
+                    .buffer(1.0f64 / 6.0f64)?; // Buffer is 1/2 of 1/3
+                ac1.0.extend(ac2.0);
+                Ok(Geometry::MultiPolygon(ac1))
+            },
+            CarlsonSmithTruchet::DIV(false) => {
+                Ok(Geometry::GeometryCollection(
+                    GeometryCollection::new_from(vec![
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, 0.5))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, -0.5))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::LineString(LineString::new(vec![
+                            coord! {x: -0.5, y: 0.0},
+                            coord! {x: 0.5, y: 0.0}]))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                    ]
+                    )))
+            },
+            CarlsonSmithTruchet::DOTS(false) => {
+                Ok(Geometry::GeometryCollection(
+                    GeometryCollection::new_from(vec![
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, 0.5))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, -0.5))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.5, 0.0))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(-0.5, -0.0))
+                            .buffer(1.0f64 / 6.0f64)
+                            .unwrap()),
+                    ])))
+            },
+            CarlsonSmithTruchet::PINWHEEL(false) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y:-0.5},
+                    coord! {x: 0.5, y: 0.5},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                let points = CarlsonSmithTruchet::DOTS(false).draw()?;
+                let out = center
+                    .union(&points)?
+                    .difference(&corners)?;
+                Ok(out)
+            },
+            CarlsonSmithTruchet::PINWHEEL(true) => {
+                Ok(Geometry::GeometryCollection(
+                    GeometryCollection::new_from(vec![
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.5, 0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.5, -0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(-0.5, 0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(-0.5, -0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                    ])))
+            },
+            CarlsonSmithTruchet::PLUS(false) => {
+                Ok(Geometry::MultiPolygon(Geometry::LineString(LineString::new(vec![
+                    coord! {x: -0.5, y: 0.0},
+                    coord! {x: 0.5, y: 0.0}]))
+                    .buffer(1.0f64 / 6.0f64)?)
+                    .union(&Geometry::MultiPolygon(Geometry::LineString(
+                        LineString::new(vec![
+                            coord!{x:0.0, y:-0.5},
+                            coord!{x:0.0, y: 0.5}]))
+                        .buffer(1.0f64 / 6.0f64)?))?)
+            },
+            CarlsonSmithTruchet::UNHAPPY(false) => {
+                Ok(Geometry::GeometryCollection(
+                    GeometryCollection::new_from(vec![
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, 0.5))
+                            .buffer(1.0f64 / 6.0f64)?),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, -0.5))
+                            .buffer(1.0f64 / 6.0f64)?),
+                        Geometry::MultiPolygon(Geometry::LineString(
+                            arc_center(0.5, 0.5, 0.5, 180.0, 270.0))
+                            .buffer(1.0f64 / 6.0f64)?)
+                    ])))
 
+            },
+            CarlsonSmithTruchet::HUGS(false) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y: 0.5},
+                    coord! {x: 0.5, y: -1.0/6.0},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                let points = CarlsonSmithTruchet::DOTS(false).draw()?;
+                let out = center
+                    .union(&points)?
+                    .difference(&corners)?;
+                Ok(out)
+            },
+            CarlsonSmithTruchet::HUGS(true) => {
+                Ok(Geometry::GeometryCollection(
+                    GeometryCollection::new_from(vec![
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.5, 0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(0.5, -0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(-0.5, 0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                        Geometry::MultiPolygon(Geometry::Point(Point::new(-0.5, -0.5))
+                            .buffer(1.0f64 / 3.0f64)
+                            .unwrap()),
+                    ])))
+            },
+            CarlsonSmithTruchet::TLBR(true) => {
+                // let dots = CarlsonSmithTruchet::DOTS(false).draw()?;
+                let dots = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                let line = Geometry::MultiPolygon(
+                    Geometry::LineString(
+                        LineString(vec![
+                            coord!{x: -0.5, y: 0.5},
+                            coord!{x:0.5, y:-0.5}
+                        ]))
+                        .buffer(1.0f64 / 5.0f64)?
+                );
+                Ok(
+                    dots.union(&line)?
+                    .difference(&CarlsonSmithTruchet::TLBR(false)
+                        .draw()?)?
+                   )
+            },
+            CarlsonSmithTruchet::DIV(true) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y:-0.5},
+                    coord! {x: 0.5, y: 0.5},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                Ok(
+                    center.union(&corners)?
+                        .difference(&CarlsonSmithTruchet::DIV(false).draw()?)?
+                )
+            },
+            CarlsonSmithTruchet::DOTS(true) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y:-0.5},
+                    coord! {x: 0.5, y: 0.5},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                Ok(
+                    center.union(&corners)?
+                        .difference(&CarlsonSmithTruchet::DOTS(false).draw()?)?
+                )
+            },
+            CarlsonSmithTruchet::PLUS(true) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y:-0.5},
+                    coord! {x: 0.5, y: 0.5},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                Ok(
+                    center.union(&corners)?
+                        .difference(&CarlsonSmithTruchet::PLUS(false).draw()?)?
+                )
 
+            },
+            CarlsonSmithTruchet::UNHAPPY(true) => {
+                let center = Geometry::Rect(Rect::<f64>::new(
+                    coord! {x:-0.5, y:-0.5},
+                    coord! {x: 0.5, y: 0.5},
+                ));
+                let corners = CarlsonSmithTruchet::PINWHEEL(true).draw()?;
+                let ac1 = Geometry::LineString(
+                    arc_center(0.5, 0.5, 0.5, 180.0, 270.0))
+                    .buffer(1.0f64 / 6.0f64)?; // Buffer is 1/2 of 1/3
+                let p1 = Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, 0.5))
+                    .buffer(1.0f64 / 6.0f64)?);
+                let p2 = Geometry::MultiPolygon(Geometry::Point(Point::new(0.0, -0.5))
+                    .buffer(1.0f64 / 6.0f64)?);
 
-
-
-
+                Ok(
+                    center.union(&corners)?
+                        .difference(&Geometry::MultiPolygon(ac1))?
+                        .difference(&p1)?
+                        .difference(&p2)?
+                )
+            }
+        }
+    }
 }
-
 
 #[cfg(test)]
-mod test{
+pub mod tests {
+    use crate::elements::CarlsonSmithTruchet;
 
-    // fn test_test(){
-    //
-    // }
+    #[test]
+    fn test_cst_all() {
+        // Basically just testing that it runs.
+        let _full_set = CarlsonSmithTruchet::full_set(false);
+        let _full_set = CarlsonSmithTruchet::full_set(true);
+
+    }
 }
+
+

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,0 +1,28 @@
+pub mod carlson_smith_truchet {
+
+    pub enum CarlsonSmithTruchet{
+        TLBR(bool),
+        DIV(bool),
+        DOTS(bool),
+        PINWHEEL(bool),
+        PLUS(bool),
+        UNHAPPY(bool),
+        HUGS(bool)
+    }
+
+
+
+
+
+
+
+}
+
+
+#[cfg(test)]
+mod test{
+
+    // fn test_test(){
+    //
+    // }
+}

--- a/src/geo_types/boolean.rs
+++ b/src/geo_types/boolean.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use geo_types::Geometry;
+use geos::Geom;
+use crate::geo_types::ToGeos;
+
+/// Boolean operations trait. Used to give boolean caps to geo_types
+/// shapes. Basically just a wrapper on geos boolean ops.
+pub trait BooleanOp
+    where Self: Sized{
+    /// Subtract other from self
+    fn difference(&self, other: &Self) -> Result<Self, Box<dyn Error>>;
+
+    /// The combination of both other and self
+    fn union(&self, other: &Self) -> Result<Self, Box<dyn Error>>;
+
+    /// Returns only the portion of self that overlaps other
+    fn intersection(&self, other: &Self) -> Result<Self, Box<dyn Error>>;
+}
+
+impl BooleanOp for Geometry<f64> {
+    fn difference(&self, other: &Self) -> Result<Self, Box<dyn Error>> {
+        let geos_self = self.to_geos()?;
+        let geos_other = other.to_geos()?;
+        Ok(Geometry::try_from(geos_self.difference(&geos_other)?)?)
+    }
+
+    fn union(&self, other: &Self) -> Result<Self, Box<dyn Error>> {
+        let geos_self = self.to_geos()?;
+        let geos_other = other.to_geos()?;
+        Ok(Geometry::try_from(geos_self.union(&geos_other)?)?)
+    }
+
+    fn intersection(&self, other: &Self) -> Result<Self, Box<dyn Error>> {
+        let geos_self = self.to_geos()?;
+        let geos_other = other.to_geos()?;
+        Ok(Geometry::try_from(geos_self.intersection(&geos_other)?)?)
+    }
+}
+

--- a/src/geo_types/buffer.rs
+++ b/src/geo_types/buffer.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use geo_types::{Geometry, MultiPolygon, };
+use geo_types::{Geometry, MultiPolygon};
 use geos::Geom;
 use crate::geo_types::flatten::FlattenPolygons;
 

--- a/src/geo_types/mod.rs
+++ b/src/geo_types/mod.rs
@@ -1,4 +1,6 @@
-use geo_types::{Point, CoordNum};
+use std::error::Error;
+use geo_types::{Point, CoordNum, Geometry, Polygon, coord, LineString};
+use geos::CoordSeq;
 use num_traits::real::Real;
 
 /// Helper module for converting geo-types geometry into something useful
@@ -23,6 +25,9 @@ pub mod buffer;
 /// Helper to flatten all the polygons from a Geometry into a MultiPolygon
 pub mod flatten;
 
+/// Boolean ops for geo_types
+pub mod boolean;
+
 /// Trait that implements a distance function between two [`geo_types::Point`] structs.
 /// Also includes a length function which returns the length of a [`geo_types::Point`]
 /// as if it were a Vector.
@@ -32,6 +37,71 @@ pub trait PointDistance<T: CoordNum> {
 
     /// Treat a [`geo_types::Point`] as a Vector and return its scalar length.
     fn length(&self) -> T;
+}
+
+/// Kinda weird that arc features are missing from geo_types, but ok, here is one.
+pub mod shapes {
+    use geo_types::{coord, Geometry, LineString, Point, Polygon};
+    use std::f64::consts::PI;
+    use num_traits::FromPrimitive;
+
+    pub fn regular_poly(sides: usize, x: f64, y: f64, radius: f64, rotation: f64) -> Geometry<f64> {
+        // all the way around to the start again, and hit the first point twice to close it.
+        if sides < 3 {
+            return Geometry::Point(Point::new(x, y));
+        }
+
+        Geometry::Polygon(Polygon::new(LineString::new((0..(sides + 2))
+            .map(|i| {
+                let angle = rotation - PI / 2.0 +
+                    (f64::from(i as i32) / f64::from(sides as i32)) * (2.0 * PI);
+                coord! {x: x+angle.cos() * radius, y: y+angle.sin() * radius}
+            }).collect()
+        ), vec![]))
+    }
+
+    pub fn circle(x0: f64, y0: f64, radius: f64) -> Geometry<f64> {
+        let radius = radius.abs();
+        let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
+        regular_poly(sides, x0, y0, radius, 0.0)
+    }
+
+    pub fn arc_center(x0: f64, y0: f64, radius: f64, deg0: f64, deg1: f64) -> LineString<f64> {
+        let radius = radius.abs();
+        // Clamp the angle.
+        let deg0 = PI * ((deg0 % 360.0) / 180.0);
+        let deg1 = PI * ((deg1 % 360.0) / 180.0);
+        let (deg0, deg1) = if deg0 > deg1 {
+            (deg1, deg0)
+        } else {
+            (deg0, deg1)
+        };
+        let sides = 1000.min(32.max(usize::from_f64(radius).unwrap_or(1000) * 4));
+        let segments = (deg1 - deg0) * f64::from(sides as i32).floor();
+        let seg_size = (deg1 - deg0) / segments;
+        let mut ls = LineString::<f64>::new(vec![]);
+        let mut angle = deg0;
+        for _segment in 0..(segments as i32) {
+            ls.0.push(coord! {x: x0+radius*angle.sin(), y: y0+radius*angle.cos()});
+            angle += seg_size;
+        }
+        if deg1 - angle > 0.0 {
+            ls.0.push(coord! {x: x0+radius*deg1.sin(), y: y0+radius*deg1.cos()});
+        }
+        ls
+    }
+
+
+    #[cfg(test)]
+    mod test {
+        use super::arc_center;
+
+        #[test]
+        fn test_arc_c() {
+            let arc = arc_center(0.0f64, 0.0f64, 10.0f64, 90.0f64, 135f64);
+            println!("ARC: {:?}", &arc);
+        }
+    }
 }
 
 impl<T> PointDistance<T> for Point<T>
@@ -47,21 +117,83 @@ impl<T> PointDistance<T> for Point<T>
     }
 }
 
+pub trait ToGeos {
+    fn to_geos(&self) -> Result<geos::Geometry, Box<dyn Error>>;
+}
+
+impl ToGeos for geo_types::Geometry<f64> {
+    fn to_geos(&self) -> Result<geos::Geometry, Box<dyn Error>> {
+        if let Geometry::GeometryCollection(collection) = self{
+            let geomap: Vec<geos::Geometry> = collection.iter()
+                .map(|item|
+                    item
+                        .to_geos()
+                        .or(
+                            geos::Geometry::create_empty_collection(
+                                geos::GeometryTypes::GeometryCollection)
+                        )
+                        .unwrap()
+                )
+                // .map_ok(|x|x)
+                .collect();
+            if let Ok(geosmap) = geos::Geometry::create_geometry_collection(geomap){
+                return Ok(geosmap);
+            } else {
+                return Err(Box::new(geos::Error::InvalidGeometry("Wrong type of geometry".into())))
+            }
+        }
+        Ok(match self {
+            Geometry::Point(p) => geos::Geometry::try_from(p),
+            Geometry::Line(line) => {
+                geos::Geometry::create_line_string(CoordSeq::new_from_vec(
+                    &vec![
+                        vec![line.start.x, line.start.y],
+                        vec![line.end.x, line.end.y]]
+                ).expect("Unexpected failure of create_line_string"))
+            }
+            Geometry::Rect(rect) => geos::Geometry::try_from(
+                Polygon::new(LineString::from(
+                    vec![
+                        rect.min(),
+                        coord!{x: rect.max().x, y: rect.min().y},
+                        rect.max(),
+                        coord!{x: rect.min().x, y: rect.max().y},
+                        rect.min(),
+                    ]),
+                             vec![])),
+            Geometry::LineString(line) => geos::Geometry::try_from(line),
+            Geometry::Polygon(poly) => geos::Geometry::try_from(poly),
+            Geometry::MultiPolygon(polys) => geos::Geometry::try_from(polys),
+            Geometry::MultiLineString(mls) => {
+                geos::Geometry::create_multiline_string(mls.0
+                    .clone()
+                    .iter()
+                    .map(|line| {
+                        geos::Geometry::try_from(line)
+                            .unwrap_or(geos::Geometry::create_empty_line_string().unwrap())
+                    })
+                    .collect())
+            },
+            _ => Err(geos::Error::InvalidGeometry("Wrong type of geometry".into()))
+        }?)
+    }
+}
+
 #[cfg(test)]
-mod tests{
+mod tests {
     use super::PointDistance;
     use geo_types::Point;
     use num_traits::abs;
 
     #[test]
-    fn test_length(){
+    fn test_length() {
         let p = Point::new(10.0f64, 0.0f64);
-        assert!(abs(p.length()-10.0) < 0.0001)
+        assert!(abs(p.length() - 10.0) < 0.0001)
     }
 
     #[test]
-    fn test_distance(){
+    fn test_distance() {
         let d = Point::new(10.0, 0.0).distance(&Point::new(0.0, 10.0));
-        assert!(abs(d-(10.0f64.powi(2)+10.0f64.powi(2)).sqrt()) < 0.0001)
+        assert!(abs(d - (10.0f64.powi(2) + 10.0f64.powi(2)).sqrt()) < 0.0001)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,17 @@
 //! [`vsk`]: https://vsketch.readthedocs.io/en/latest/index.html
 //!
 //! # Changelog
+//! * 0.1.11. Added the first "element" (reusable sketch component) in the form
+//!          of the [`elements::CarlsonSmithTruchet`], which provides tileable
+//!          and scalable truchets which make for some very interesting patterns.
+//!          Think of them as the "goto 10" tiles on steroids.
+//!          Also added a to_geos trait which makes it easy to convert
+//!          back and forth from geo_types without fancy and unpredictable
+//!          From/Into magic.
+//!          Also added a [`geo_types::shapes`] module which provides some
+//!          additional primitives (arc, polygons, circles).
+//!          Added the [`geo_types::boolean::BooleanOp`] trait to allow for
+//!          boolean operations directly against geo_types.
 //! * 0.1.10. Getting close to having to do a 0.2 release. Added the 'flatten'
 //!          method to [`context::Context`] so that you can merge all your
 //!          pen strokes that live on the same layer. Good for merging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,9 @@ pub mod context;
 /// Errors
 pub mod errors;
 
+/// Elements : Reusable art components, usually designed for use with Context
+pub mod elements;
+
 /// Make your life easy! Just import prelude::* and ignore all the warnings!
 /// One stop shopping at the expense of a slightly more complex dependency graph.
 pub mod prelude {


### PR DESCRIPTION
Release 0.1.11. Added "Elements"
    
 * The first "element" (reusable sketch component) in the form
    of the [`elements::CarlsonSmithTruchet`], which provides tileable
    and scalable truchets which make for some very interesting patterns.
    Think of them as the "goto 10" tiles on steroids.
 * Also added a to_geos trait which makes it easy to convert
    back and forth from geo_types without fancy and unpredictable
    From/Into magic.
 * Also added a [`geo_types::shapes`] module which provides some
    additional primitives (arc, polygons, circles).
 * Added the [`geo_types::boolean::BooleanOp`] trait to allow for
    boolean operations directly against geo_types.
